### PR TITLE
Fix a crash on Oreo produced by casting an AdaptiveIconDrawable to BitmapDrawable.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.2'
     defaultConfig {
         applicationId "com.luseen.sample"
         minSdkVersion 15
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }
@@ -23,6 +23,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.0.0'
+    compile 'com.android.support:appcompat-v7:26.1.0'
     compile project(':verticalintrolibrary')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,10 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.2'
@@ -12,6 +16,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/verticalintrolibrary/build.gradle
+++ b/verticalintrolibrary/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         vectorDrawables.useSupportLibrary = true
@@ -25,7 +25,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.0.0'
+    compile 'com.android.support:appcompat-v7:26.1.0'
 }
 
 publish {

--- a/verticalintrolibrary/src/main/java/com/luseen/verticalintrolibrary/Utils.java
+++ b/verticalintrolibrary/src/main/java/com/luseen/verticalintrolibrary/Utils.java
@@ -8,9 +8,12 @@ import android.app.ActivityManager;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.drawable.AdaptiveIconDrawable;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
 import android.view.View;
 import android.widget.TextView;
@@ -107,7 +110,7 @@ class Utils {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             try {
                 Drawable appIcon = activity.getPackageManager().getApplicationIcon(activity.getPackageName());
-                Bitmap bm = ((BitmapDrawable) appIcon).getBitmap();
+                Bitmap bm = getBitmapFromDrawable(appIcon);
                 int recentAppsStyleColor = ContextCompat.getColor(activity, targetColor);
                 ActivityManager.TaskDescription taskDescription =
                         new ActivityManager.TaskDescription(
@@ -117,5 +120,15 @@ class Utils {
                 e.printStackTrace();
             }
         }
+    }
+
+    @NonNull
+    private static Bitmap getBitmapFromDrawable(@NonNull Drawable drawable) {
+        Bitmap bmp = Bitmap.createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(),
+                Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bmp);
+        drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+        drawable.draw(canvas);
+        return bmp;
     }
 }

--- a/verticalintrolibrary/src/main/java/com/luseen/verticalintrolibrary/VerticalViewPager.java
+++ b/verticalintrolibrary/src/main/java/com/luseen/verticalintrolibrary/VerticalViewPager.java
@@ -13,7 +13,7 @@ import java.lang.reflect.Field;
  * Created by Chatikyan on 18.10.2016.
  */
 
-class VerticalViewPager extends ViewPager {
+public class VerticalViewPager extends ViewPager {
 
     private ScrollerCustomDuration mScroller;
 


### PR DESCRIPTION
Here is an issue https://github.com/armcha/Vertical-Intro/issues/7. Also I've updated the version of buildTools and targetSdkVersion to 26 to support adaptive icons.